### PR TITLE
Add admin menu based on page classes

### DIFF
--- a/src/Admin/Bootstrap.php
+++ b/src/Admin/Bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lapisense\Admin;
+
+class Bootstrap
+{
+    /** @var Menu */
+    public $menu;
+
+    public function setup()
+    {
+        $this->menu = new Menu();
+        $this->menu->setup();
+    }
+}

--- a/src/Admin/Menu.php
+++ b/src/Admin/Menu.php
@@ -4,6 +4,7 @@ namespace Lapisense\Admin;
 
 use Lapisense\Admin\Pages\ActivationsPage;
 use Lapisense\Admin\Pages\KeysPage;
+use Lapisense\Admin\Pages\MainPage;
 use Lapisense\Admin\Pages\Page;
 use Lapisense\Admin\Pages\SettingsPage;
 
@@ -57,6 +58,10 @@ class Menu
     public function pageDispatcher()
     {
         $pages = apply_filters('lapisense_admin_menu_pages', [
+            [
+                'slug' => 'lapisense',
+                'class' => MainPage::class,
+            ],
             [
                 'slug' => 'lapisense-keys',
                 'class' => KeysPage::class,

--- a/src/Admin/Menu.php
+++ b/src/Admin/Menu.php
@@ -2,6 +2,11 @@
 
 namespace Lapisense\Admin;
 
+use Lapisense\Admin\Pages\ActivationsPage;
+use Lapisense\Admin\Pages\KeysPage;
+use Lapisense\Admin\Pages\Page;
+use Lapisense\Admin\Pages\SettingsPage;
+
 class Menu
 {
     public function setup()
@@ -51,6 +56,30 @@ class Menu
 
     public function pageDispatcher()
     {
-        echo 'hello world';
+        $pages = apply_filters('lapisense_admin_menu_pages', [
+            [
+                'slug' => 'lapisense-keys',
+                'class' => KeysPage::class,
+            ],
+            [
+                'slug' => 'lapisense-activations',
+                'class' => ActivationsPage::class,
+            ],
+            [
+                'slug' => 'lapisense-settings',
+                'class' => SettingsPage::class,
+            ]
+        ]);
+
+        $currentPage = filter_input(INPUT_GET, 'page');
+
+        foreach( $pages as $page ) {
+            if ( $currentPage === $page['slug'] ) {
+                /** @var Page $pageHandler */
+                $pageHandler = new $page['class']();
+                $pageHandler->setup();
+                $pageHandler->output();
+            }
+        }
     }
 }

--- a/src/Admin/Menu.php
+++ b/src/Admin/Menu.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Lapisense\Admin;
+
+class Menu
+{
+    public function setup()
+    {
+        add_action('admin_menu', [$this, 'addMenu']);
+    }
+
+    public function addMenu()
+    {
+        add_menu_page(
+            __('Lapisense', 'lapisense'),
+            __('Lapisense', 'lapisense'),
+            'manage_options',
+            'lapisense',
+            [$this, 'pageDispatcher'],
+            '',
+            58
+        );
+
+        add_submenu_page(
+            'lapisense',
+            __('License keys', 'lapisense'),
+            __('License keys', 'lapisense'),
+            'manage_options',
+            'lapisense-keys',
+            [$this, 'pageDispatcher']
+        );
+
+        add_submenu_page(
+            'lapisense',
+            __('Activation', 'lapisense'),
+            __('Activations', 'lapisense'),
+            'manage_options',
+            'lapisense-activations',
+            [$this, 'pageDispatcher']
+        );
+
+        add_submenu_page(
+            'lapisense',
+            __('Settings', 'lapisense'),
+            __('Settings', 'lapisense'),
+            'manage_options',
+            'lapisense-settings',
+            [$this, 'pageDispatcher']
+        );
+    }
+
+    public function pageDispatcher()
+    {
+        echo 'hello world';
+    }
+}

--- a/src/Admin/Pages/ActivationsPage.php
+++ b/src/Admin/Pages/ActivationsPage.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Lapisense\Admin\Pages;
+
+class ActivationsPage extends Page
+{
+
+}

--- a/src/Admin/Pages/ActivationsPage.php
+++ b/src/Admin/Pages/ActivationsPage.php
@@ -4,11 +4,6 @@ namespace Lapisense\Admin\Pages;
 
 class ActivationsPage extends Page
 {
-    public function setup()
-    {
-
-    }
-
     public function output()
     {
         echo 'This is the activations page';

--- a/src/Admin/Pages/ActivationsPage.php
+++ b/src/Admin/Pages/ActivationsPage.php
@@ -4,5 +4,13 @@ namespace Lapisense\Admin\Pages;
 
 class ActivationsPage extends Page
 {
+    public function setup()
+    {
 
+    }
+
+    public function output()
+    {
+        echo 'This is the activations page';
+    }
 }

--- a/src/Admin/Pages/KeysPage.php
+++ b/src/Admin/Pages/KeysPage.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Lapisense\Admin\Pages;
+
+class KeysPage extends Page
+{
+
+}

--- a/src/Admin/Pages/KeysPage.php
+++ b/src/Admin/Pages/KeysPage.php
@@ -4,11 +4,6 @@ namespace Lapisense\Admin\Pages;
 
 class KeysPage extends Page
 {
-    public function setup()
-    {
-
-    }
-
     public function output()
     {
         echo 'This is the license keys page';

--- a/src/Admin/Pages/KeysPage.php
+++ b/src/Admin/Pages/KeysPage.php
@@ -4,5 +4,13 @@ namespace Lapisense\Admin\Pages;
 
 class KeysPage extends Page
 {
+    public function setup()
+    {
 
+    }
+
+    public function output()
+    {
+        echo 'This is the license keys page';
+    }
 }

--- a/src/Admin/Pages/MainPage.php
+++ b/src/Admin/Pages/MainPage.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Lapisense\Admin\Pages;
+
+class MainPage extends Page
+{
+    public function output()
+    {
+        echo 'This is the main page';
+    }
+}

--- a/src/Admin/Pages/Page.php
+++ b/src/Admin/Pages/Page.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Lapisense\Admin\Pages;
+
+abstract class Page
+{
+
+}

--- a/src/Admin/Pages/Page.php
+++ b/src/Admin/Pages/Page.php
@@ -4,5 +4,10 @@ namespace Lapisense\Admin\Pages;
 
 abstract class Page
 {
+    public function setup()
+    {
+        // This method can be overridden by implementing class to perform a specific setup
+    }
 
+    abstract public function output();
 }

--- a/src/Admin/Pages/SettingsPage.php
+++ b/src/Admin/Pages/SettingsPage.php
@@ -4,5 +4,13 @@ namespace Lapisense\Admin\Pages;
 
 class SettingsPage extends Page
 {
+    public function setup()
+    {
 
+    }
+
+    public function output()
+    {
+        echo 'This is the settings page';
+    }
 }

--- a/src/Admin/Pages/SettingsPage.php
+++ b/src/Admin/Pages/SettingsPage.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Lapisense\Admin\Pages;
+
+class SettingsPage extends Page
+{
+
+}

--- a/src/Admin/Pages/SettingsPage.php
+++ b/src/Admin/Pages/SettingsPage.php
@@ -4,11 +4,6 @@ namespace Lapisense\Admin\Pages;
 
 class SettingsPage extends Page
 {
-    public function setup()
-    {
-
-    }
-
     public function output()
     {
         echo 'This is the settings page';

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2,9 +2,16 @@
 
 namespace Lapisense;
 
+use Lapisense\Admin\Bootstrap;
+
 class Plugin
 {
+    /** @var Bootstrap */
+    public $admin;
+
     public function setup()
     {
+        $this->admin = new Bootstrap();
+        $this->admin->setup();
     }
 }


### PR DESCRIPTION
This introduces the `Page` abstract and corresponding implementation for the basic administration panel pages, that are being dispatched by the `Menu` class. Each page can fully control their own output, which comes into play as soon as list tables (for keys and activations) and the Settings API (for the settings page) are implemented.